### PR TITLE
Updated Visualization page with options toggle

### DIFF
--- a/src/assets/css/stage.css
+++ b/src/assets/css/stage.css
@@ -7,6 +7,7 @@
     border: 2px solid black;
     align-items: center;
     margin-top: 6%;
+    padding-bottom: 2%;
   }
 
 .stage button {

--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -4,6 +4,10 @@ import Dropdown from "./Dropdown";
 import XItemList from './XitemList';
 import ApiService from '../services/ApiService';
 
+interface StageProps {
+    onShowOptionsChange: (showOptions: boolean) => void;
+}
+
 let socket:WebSocket;
 
 // Callback for status updates
@@ -42,13 +46,14 @@ function connectWebSocket(addr: String) {
     });
   }
 
-export default function Stage() {
+export default function Stage({onShowOptionsChange}: StageProps) {
     connectWebSocket(ApiService.getApiServiceUrl());
 
     const options = ['Upload', 'Classify', 'Classifications']
     const dataTypes = ['Planetscope Superdove', 'Orbital Megalaser', 'Global Gigablaster']
     const modelTypes = ['XGBoost', 'Random Forest', 'Neural Network']
     const [images, setImages] = useState<String[]>([])
+    const [showOptions, setShowOptions] = useState(true)
 
     useEffect(() => {
         const imagesEndpoint = `${ApiService.getApiServiceUrl()}/images`
@@ -152,11 +157,25 @@ export default function Stage() {
             break;
     }
     
-    return (
-        <div className='stage'>
-            <h1>Current Service: {option}</h1>
-            <Dropdown options={options} selected={option} setSelected={setOption}/>
-            {stage}
-        </div>
-  )
+    if(showOptions){
+        return (
+            <div className='stage'>
+                <h1>Current Service: {option}</h1>
+                <Dropdown options={options} selected={option} setSelected={setOption}/>
+                {stage}
+                <button onClick={() => {
+                    setShowOptions(false)
+                    onShowOptionsChange(showOptions)
+                }}>Hide Options</button>
+            </div>
+      )
+    } else {
+        return (
+            <button style={{fontSize: "1.5vw"}} onClick={() => {
+                setShowOptions(true)
+                onShowOptionsChange(showOptions)
+            }}>Show Options</button>
+        )
+    }
+    
 }

--- a/src/pages/Visualization.tsx
+++ b/src/pages/Visualization.tsx
@@ -1,10 +1,21 @@
-import React from 'react';
+import {useState} from 'react';
 import LeafletMap from '../components/LeafletMap';
 import '../assets/css/visualization.css';
 import Stage from "../components/Stage";
 import ProgressBar from "@ramonak/react-progress-bar";
 
 export default function Visualization() {
+  const [stageStyle, setStageStyle] = useState({});
+  const [mapStyle, setMapStyle] = useState({});
+  const handleOptionsChange = (showOptions: boolean) => {
+    if(showOptions){
+      setStageStyle({width: "100px", margin: "0px", padding: "0px"})
+      setMapStyle({width:"120%"})
+    } else {
+      setStageStyle({})
+      setMapStyle({})
+    }
+  }
   return (
     <div id='container'>
       <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -18,10 +29,10 @@ export default function Visualization() {
         animateOnRender={true}
       />
       <div id='classification'>
-        <div id='left-menu'>
-          <Stage />
+        <div id='left-menu' style={stageStyle}>
+          <Stage onShowOptionsChange={handleOptionsChange}/>
         </div>
-        <div id='right-menu'>
+        <div id='right-menu' style={mapStyle}>
           <LeafletMap />
         </div>
       </div>


### PR DESCRIPTION
I added a button that can be used to toggle options view. If enabled, the Stage component is show and LeafletMap is set at its default size. If disabled, the Stage component is not shown and LeafletMap is set to a larger size that takes up the screen.